### PR TITLE
Add oauth2client dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client
+oauth2client

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     url="http://github.com/cleardataeng/google-api-python-client-helpers/",
     install_requires=[
         'google-api-python-client',
+        'oauth2client',
     ],
     packages=[
         'googleapiclienthelpers',


### PR DESCRIPTION
google-api-python-client removed it as a dependency in favor of the google.auth library, so we need to add it explicitly